### PR TITLE
Scrape members of the Senate, not just House of Representatives

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/everypolitician/field_serializer.git
-  revision: 16d5d90a3095fa2552cbeeb3fb371b3f409ffd63
+  revision: 07e89a97eebe4e85ec23f46e04c7e061ac0fe166
   specs:
-    field_serializer (0.1.0)
+    field_serializer (0.3.0)
 
 GIT
   remote: https://github.com/everypolitician/scraped_page_archive.git

--- a/scraper.rb
+++ b/scraper.rb
@@ -27,7 +27,7 @@ class Page
   end
 
   def noko
-    @html ||= open(url) { |f| f.read }
+    @html ||= open(url, &:read)
     @noko ||= Nokogiri::HTML(@html)
   end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -66,7 +66,7 @@ class MemberPage < Page
   end
 
   field :title do
-    $1 if name_with_title.match(TITLE_RE)
+    name_with_title[TITLE_RE, 1]
   end
 
   field :constituency do

--- a/scraper.rb
+++ b/scraper.rb
@@ -46,7 +46,7 @@ class SearchPage < Page
   end
 
   field :url do
-    url
+    @url
   end
 
   private

--- a/scraper.rb
+++ b/scraper.rb
@@ -126,7 +126,9 @@ class MemberPage < Page
     #
     # The first "Hon" in those conditionals might be "Sen" in some
     # pages. This field extracts that string:
-    @html[/if\("(.*)" == "Sen"\)\{/, 1]
+    pos = @html[/if\("(.*)" == "Sen"\)\{/, 1]
+    raise "Unexpected js_position: #{pos}" unless %w(Sen Hon).include?(pos)
+    pos
   end
 
   field :position do


### PR DESCRIPTION
This commit changes the scraper to also include members of the Senate.
This means that the instructions.json for the House of Representatives
of Nigeria in everypolitician-data will need to be updated to only
SELECT those with a title of 'Hon.' in order to preserve the original
behaviour.