### PR TITLE
Don't return ', State' as the area when area information is missing

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -77,7 +77,7 @@ class MemberPage < Scraped::HTML
   end
 
   field :area do
-    [constituency, state].join(', ')
+    constituency.empty? ? '' : [constituency, state].join(', ')
   end
 
   field :phone do


### PR DESCRIPTION
There are several cases on the website where people are missing
constituency information - in these cases the constituency box is empty
and the state box just contains 'State'. It's confusing to return
', State' as the area field in those cases, whereas an empty string
would more clearly convey that the information is absent.