### PR TITLE
Manually add a couple more rep pages missing from the search index

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -139,6 +139,10 @@ member_urls |= [
   'http://www.nass.gov.ng/mp/profile/675',
   # Hon. D Goodhead Boma
   'http://www.nass.gov.ng/mp/profile/826',
+  # Hon. Ugwuegede Ikechukwu
+  'http://www.nass.gov.ng/mp/profile/952',
+  # Hon. Jerome Eke
+  'http://www.nass.gov.ng/mp/profile/831',
 ]
 
 data = member_urls.map do |url|


### PR DESCRIPTION
These two representatives were no longer being found by the scraper,
but their pages still exist on the website. We should still scrape
them since they were being found in the previous scraped data and
it's bad when people just disappear.