### PR TITLE
Extract the fullest version of the name in this page

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -29,11 +29,11 @@ class MemberPage < Scraped::HTML
     name_with_title[TITLE_RE, 1]
   end
 
-  field :name do
+  field :shorter_name do
     name_with_title.gsub(TITLE_RE, '')
   end
 
-  field :full_name do
+  field :name do
     noko.xpath('.//h1/text()').text.tidy.gsub(TITLE_RE, '')
   end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -33,6 +33,10 @@ class MemberPage < Scraped::HTML
     name_with_title.gsub(TITLE_RE, '')
   end
 
+  field :full_name do
+    noko.xpath('.//h1/text()').text.tidy.gsub(TITLE_RE, '')
+  end
+
   field :constituency do
     box.xpath('.//th[text()="Constituency"]/following-sibling::td').text.tidy
   end


### PR DESCRIPTION
This PR makes the fullest name the `name` column and adds
the shorter version as `shorter_name`. I'm intending to use
the SQL query in instructions.json to alias `shorter_name` to
`other_names`, since it we later scraped other variations of the
name to new columns, they could be semi-colon-joined to make
the `other_names` field in the query.