### PR TITLE
Ignore the placeholder 'missing image' image URL

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -69,7 +69,8 @@ class MemberPage < Scraped::HTML
   end
 
   field :image do
-    box.css('.carousel-inner img/@src').text
+    image_url = box.css('.carousel-inner img/@src').text
+    image_url.include?('/avatar.jpg') ? nil : image_url
   end
 
   field :term do


### PR DESCRIPTION
I think it's more helpful to have a clear indication of when an image is
missing, by having the image column be NULL, rather than having the URL
of a placeholder image there; this commit makes that change.